### PR TITLE
Implement PSU presence,power,name get function

### DIFF
--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/chassis.py
@@ -21,6 +21,7 @@ class Chassis(ChassisBase):
     """Platform-specific Chassis class"""
 
     FAN_CONFIG = 'fan.json'
+    PSU_CONFIG = 'psu.json'
 
     def __init__(self):
         ChassisBase.__init__(self)
@@ -28,6 +29,7 @@ class Chassis(ChassisBase):
         self._api_config = self._api_common.get_config_path()
 
         self.__initialize_fan()
+        self.__initialize_psu()
 
         # self.is_host = self._api_common.is_host()
 
@@ -59,11 +61,18 @@ class Chassis(ChassisBase):
     #         self._sfp_list.append(sfp)
     #     self.sfp_module_initialized = True
 
-    # def __initialize_psu(self):
-    #     from sonic_platform.psu import Psu
-    #     for index in range(0, NUM_PSU):
-    #         psu = Psu(index)
-    #         self._psu_list.append(psu)
+    def __initialize_psu(self):
+        from sonic_platform.psu import Psu
+
+        psu_config_path = os.path.join(self._api_config, self.PSU_CONFIG)
+        psu_config = self._api_common.load_json_file(psu_config_path)
+        
+        if psu_config:
+            psu_index = 0
+            for index in range(0, psu_config['psu_num']):
+                psu = Psu(psu_index, conf=psu_config)
+                psu_index += 1
+                self._psu_list.append(psu)
 
     # def __initialize_thermals(self):
     #     from sonic_platform.thermal import Thermal

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/common.py
@@ -77,6 +77,8 @@ class Common:
         if config.get('output_transform'):
             ret_val = config['output_transform'].get(
                 result, config['default_output'])
+        elif config.get('output_formula'):
+            ret_val = eval(config['output_formula'][index].format(result))
         else:
             ret_val = eval(config['formula'].format(result))
         return status, ret_val

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/psu.py
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform/psu.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python
+
+#############################################################################
+# Celestica
+#
+# Module contains an implementation of SONiC Platform Base API and
+# provides the fan status which are available in the platform
+#
+#############################################################################
+
+import json
+import math
+import os.path
+import inspect
+
+try:
+    from sonic_platform_base.psu_base import PsuBase
+    from common import Common
+except ImportError as e:
+    raise ImportError(str(e) + "- required module not found")
+
+
+class Psu(PsuBase):
+    """Platform-specific Fan class"""
+
+    def __init__(self, index, psu_index=0, conf=None):
+        PsuBase.__init__(self)
+
+        self.psu_index = index
+
+        self._config = conf
+        self._api_common = Common()
+        self._name = self.get_name()
+        #self._is_psu_fan = is_psu_fan
+
+        # self._is_psu_fan = is_psu_fan
+        # if self._is_psu_fan:
+        #     self.psu_index = psu_index
+        #     self.psu_i2c_num = PSU_I2C_MAPPING[self.psu_index]["num"]
+        #     self.psu_i2c_addr = PSU_I2C_MAPPING[self.psu_index]["addr"]
+        #     self.psu_hwmon_path = PSU_HWMON_PATH.format(
+        #         self.psu_i2c_num, self.psu_i2c_addr)
+
+    def get_num_fans(self):
+        """
+        Retrieves the number of fan modules available on this PSU
+
+        Returns:
+            An integer, the number of fan modules available on this PSU
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get("get_name")
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        __fan_list = psu_attr['fan_name']
+
+        return len(self._fan_list) if self.get_presence() else default
+
+    def get_all_fans(self):
+        """
+        Retrieves all fan modules available on this PSU
+
+        Returns:
+            A list of objects derived from FanBase representing all fan
+            modules available on this PSU
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get("get_name")
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        __fan_list = psu_attr['fan_name']
+
+        return self._fan_list if self.get_presence() else default
+
+    def get_fan(self, index):
+        """
+        Retrieves fan module represented by (0-based) index <index>
+
+        Args:
+            index: An integer, the index (0-based) of the fan module to
+            retrieve
+
+        Returns:
+            An object dervied from FanBase representing the specified fan
+            module
+        """
+        fan = None
+
+        try:
+            fan = self._fan_list[index]
+        except IndexError:
+            sys.stderr.write("Fan index {} out of range (0-{})\n".format(
+                             index, len(self._fan_list)-1))
+
+        return fan
+
+    def get_voltage(self):
+        """
+        Retrieves current PSU voltage output
+
+        Returns:
+            A float number, the output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_current(self):
+        """
+        Retrieves present electric current supplied by PSU
+
+        Returns:
+            A float number, the electric current in amperes, e.g 15.4
+        """
+        raise NotImplementedError
+
+    def get_power(self):
+        """
+        Retrieves current energy supplied by PSU
+
+        Returns:
+            A float number, the power in watts, e.g. 302.6
+        """
+        
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        ret_val = 0
+
+        if self.get_presence() and config.get('oper_type') == Common.OPER_IMPI:
+            status, result = self._api_common.ipmi_get(self.psu_index, config)
+            raw_val = result if status else ret_val
+
+        return float(raw_val)
+
+    def get_powergood_status(self):
+        """
+        Retrieves the powergood status of PSU
+
+        Returns:
+            A boolean, True if PSU has stablized its output voltages and passed all
+            its internal self-tests, False if not.
+        """
+        raise NotImplementedError
+
+    def set_status_led(self, color):
+        """
+        Sets the state of the PSU status LED
+
+        Args:
+            color: A string representing the color with which to set the
+                   PSU status LED
+
+        Returns:
+            bool: True if status LED state is set successfully, False if not
+        """
+        raise NotImplementedError
+
+    def get_status_led(self):
+        """
+        Gets the state of the PSU status LED
+
+        Returns:
+            A string, one of the predefined STATUS_LED_COLOR_* strings above
+        """
+        raise NotImplementedError
+
+    def get_temperature(self):
+        """
+        Retrieves current temperature reading from PSU
+
+        Returns:
+            A float number of current temperature in Celsius up to nearest thousandth
+            of one degree Celsius, e.g. 30.125 
+        """
+        raise NotImplementedError
+
+    def get_temperature_high_threshold(self):
+        """
+        Retrieves the high threshold temperature of PSU
+
+        Returns:
+            A float number, the high threshold temperature of PSU in Celsius
+            up to nearest thousandth of one degree Celsius, e.g. 30.125
+        """
+        raise NotImplementedError
+
+    def get_voltage_high_threshold(self):
+        """
+        Retrieves the high threshold PSU voltage output
+
+        Returns:
+            A float number, the high threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_voltage_low_threshold(self):
+        """
+        Retrieves the low threshold PSU voltage output
+
+        Returns:
+            A float number, the low threshold output voltage in volts, 
+            e.g. 12.1 
+        """
+        raise NotImplementedError
+
+    def get_name(self):
+        """
+        Retrieves the name of the device
+            Returns:
+            string: The name of the device
+        """
+        default = Common.NULL_VAL
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+
+        psu_attr = self._api_common.get_val(self.psu_index, config, default)
+        
+        psu_name = psu_attr['psu_name']
+
+        return psu_name if self.get_presence() else default
+
+    def get_presence(self):
+        """
+        Retrieves the presence of the PSU
+        Returns:
+            bool: True if PSU is present, False if not
+        """
+        f_name = inspect.stack()[0][3]
+        config = self._config.get(f_name)
+        ret_val = False
+
+        if config.get('oper_type') == Common.OPER_IMPI:
+            status, result = self._api_common.ipmi_get(self.psu_index, config)
+            ret_val = result if status else ret_val
+
+        return ret_val

--- a/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/psu.json
+++ b/device/celestica/x86_64-cel_seastone_2-r0/sonic_platform_config/psu.json
@@ -1,0 +1,43 @@
+{
+    "psu_num": 2,
+    "fan_per_psu_num": 1,
+    "get_name": {
+            "oper_type": "fixed_list",
+            "value": [
+                    {
+                        "psu_name":"PSU-R",
+                        "fan_name":[
+                            "PSU-R-Fan"
+                        ],
+                        "presence_bit":4
+                    },
+                    {
+                        "psu_name":"PSU-L",
+                        "fan_name":[
+                            "PSU-L-Fan"
+                        ],
+                        "presence_bit":5
+                    }
+            ]
+    },
+    "get_power": {
+        "oper_type": "ipmi",
+        "command_template": "ipmitool sdr | grep {}",
+        "command": [
+            "PSUR_POut",
+            "PSUL_POut"
+        ],
+        "formula": "float('{}'.split()[2])"
+    },
+    "get_presence": {
+            "oper_type": "ipmi",
+            "command_template": "ipmitool raw 0x3a 0x0c 0x00 0x2 0x60",
+            "command":["0","0"],
+            "output_formula": [
+                "True if bin(0x{})[2:][::-1][4]=='0' else False",
+                "True if bin(0x{})[2:][::-1][5]=='0' else False"
+            ],
+            "default_output": "off"
+            
+    }
+}


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- Why I did it**
Implement the following requirement from JIRA CSC-335.
**- How I did it**
Implement API to get the PSU PowerOut, Static name, and Presence status. 
**- How to verify it**
Use the below example script to get the output
```python
#!/usr/bin/env

import time
import json
import sys
from sonic_platform import platform

print "============================ NEW API REPORT =============================="

platform = platform.Platform()
chassis = platform.get_chassis()

print "\n=============================== TEST PSU API ================================\n"

num_psu = chassis.get_num_psus()
all_psu = chassis.get_all_psus()
print "num of psus:\t", num_psu
# print "all psu:\t", all_psu
for psu in all_psu:
    print ""
    print "Name:\t\t\t", psu.get_name()
    print "Present:\t\t", psu.get_presence()
    print "Power:\t\t\t", psu.get_power()
```

Output:
```
root@sonic:/home/admin# python test_psu.py 
============================ NEW API REPORT ==============================

=============================== TEST PSU API ================================

num of psus:    2

Name:                   PSU-R
Present:                True
Power:                  100.0

Name:                   PSU-L
Present:                True
Power:                  110.0
```

IPMI output for reference:
```
root@sonic:/home/admin# ipmitool sdr
...
Fan1_Status      | 0x00              | ok
Fan2_Status      | 0x00              | ok
Fan3_Status      | 0x00              | ok
Fan4_Status      | 0x00              | ok
PSUL_Status      | 0x00              | ok
PSUR_Status      | 0x00              | ok
PowerStatus      | 0x00              | ok
...
PSUL_VIn         | 220 Volts         | ok
PSUL_CIn         | 0.60 Amps         | ok
PSUL_PIn         | 130 Watts         | ok
PSUL_Temp1       | 26 degrees C      | ok
PSUL_Temp2       | 35 degrees C      | ok
PSUL_Fan         | 12100 RPM         | ok
PSUL_VOut        | 12 Volts          | ok
PSUL_COut        | 9 Amps            | ok
PSUL_POut        | 110 Watts         | ok
PSUR_VIn         | 220 Volts         | ok
PSUR_CIn         | 0.50 Amps         | ok
PSUR_PIn         | 110 Watts         | ok
PSUR_Temp1       | 27 degrees C      | ok
PSUR_Temp2       | 33 degrees C      | ok
PSUR_Fan         | 12200 RPM         | ok
PSUR_VOut        | 12 Volts          | ok
PSUR_COut        | 8.10 Amps         | ok
PSUR_POut        | 100 Watts         | ok
...
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
Design the JSON for support PSU attr and new common function to process the output to support get_presence, implement get_power following the design from FAN func. 
